### PR TITLE
Activity items done properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(action_files
 )
 
 set(msg_files
+  "msg/ActivityItem.msg"
   "msg/Behaviour.msg"
   "msg/BehaviourTree.msg"
   "msg/KeyValue.msg"

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@
 | CI | - | [![Build-Eloquent][build-eloquent-image]][build-eloquent] | [![Build-Dashing][build-dashing-image]][build-dashing] | [![Build-Crystal][build-crystal-image]][build-crystal] |
 | Docs | - | ![Docs-Eloquent][docs-not-available-image] | ![Docs-Dashing][docs-not-available-image] | ![Docs-Crystal][docs-not-available-image] |
 
+
 [ros-index-eloquent]: https://index.ros.org/p/py_trees_ros_interfaces/github-splintered-reality-py_trees_ros_interfaces/#eloquent
 [ros-index-eloquent-image]: http://img.shields.io/badge/rosindex-eloquent-blue.svg?style=plastic
 [ros-index-dashing]: https://index.ros.org/p/py_trees_ros_interfaces/github-splintered-reality-py_trees_ros_interfaces/#dashing

--- a/msg/ActivityItem.msg
+++ b/msg/ActivityItem.msg
@@ -1,0 +1,27 @@
+##############################################################################
+#
+# A single blackboard activity item
+#
+#    key: the active blackboard key
+#    client_name : name of the blackboard client accessing the key
+#    activity_type: type of operation attempted on the ky
+#    previous_value: if the key was modified, stores the previous value of the key
+#    current_value: if the key was modified, stores the current value of the key
+#
+##############################################################################
+
+# Activity types
+string READ = "READ"
+string INITIALISED = "INITIALISED"
+string WRITE = "WRITE"
+string ACCESSED = "ACCESSED"
+string ACCESS_DENIED = "ACCESS_DENIED"
+string NO_KEY = "NO_KEY"
+string NO_OVERWRITE = "NO_OVERWRITE"
+string UNSET = "UNSET"
+
+string key
+string client_name
+string activity_type
+string previous_value
+string current_value

--- a/msg/BehaviourTree.msg
+++ b/msg/BehaviourTree.msg
@@ -13,10 +13,7 @@ bool changed
 ##############################################################################
 
 diagnostic_msgs/KeyValue[] blackboard_on_visited_path
-
-# Ideally, pass all the details and reconstruct on the
-# other side, but quick and dirty works for now
-string blackboard_activity_stream
+ActivityItem[] blackboard_activity
 
 ##############################################################################
 # Other

--- a/msg/SnapshotStreamParameters.msg
+++ b/msg/SnapshotStreamParameters.msg
@@ -7,7 +7,6 @@
 #    snapshot_period: period between snapshots (use /inf to only publish on tree status changes)
 #
 ##############################################################################
-# Configuration for a snapshot stream.
 
 float32 snapshot_period
 bool blackboard_data


### PR DESCRIPTION
`ActivityItem.msg` establishes activity info formally rather than a console formatted snippet, this makes it easier to handle a garden variety of use cases on the other side (command line client, web app).
