### PR TITLE
Add generic COMPOSITE enum in Behaviour message type

### DIFF
--- a/msg/Behaviour.msg
+++ b/msg/Behaviour.msg
@@ -12,6 +12,7 @@ uint8 SELECTOR = 3
 uint8 PARALLEL = 4
 uint8 CHOOSER = 5
 uint8 DECORATOR = 6
+uint8 COMPOSITE = 7
 
 # Blackbox Level - these must match py_trees.common.BlackBoxLevel
 uint8 BLACKBOX_LEVEL_DETAIL = 1


### PR DESCRIPTION
To be able to differentiate between one of the 3 main composites (Sequence, Selector, and Parallel) vs. user-defined ones.